### PR TITLE
Chang a line to avoid an invalid casting

### DIFF
--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -262,5 +262,5 @@ void IRAM_ATTR SoftwareSerial::rxRead() {
    }
    // Must clear this bit in the interrupt register,
    // it gets set even when interrupts are disabled
-   GPIO_REG_WRITE(GPIO.status_w1tc, 1 << m_rxPin);
+   GPIO_REG_WRITE(GPIO.status_w1tc.status_w1tc, 1 << m_rxPin);
 }


### PR DESCRIPTION
If you use the following line directly,
```c
GPIO_REG_WRITE(GPIO.status_w1tc, 1 << m_rxPin);
```
it will occur to Error :"no suitable conversion function from "volatile union gpio_dev_s::<unnamed>" to "volatile uint32_t *" existsC/C++(413)"
So, I change the line to
```c
GPIO_REG_WRITE(GPIO.status_w1tc.status_w1tc, 1 << m_rxPin);
```
to avoid invaild cast